### PR TITLE
History penalty for captures

### DIFF
--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -374,7 +374,9 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
             }
             for (int j = 0; j < i; j++) {
               int mov2 = Bitboards.moves[ply][j];
-              if (!iscapture(mov2)) {
+              if (iscapture(mov2)) {
+                Histories.updatenoisyhistory(mov2, -3 * depth);
+              } else {
                 Histories.updatequiethistory(mov2, -3 * depth);
               }
             }

--- a/history.cpp
+++ b/history.cpp
@@ -30,7 +30,7 @@ int History::movescore(int move) {
   int piece = (move >> 13) & 7;
   int captured = (move >> 17) & 7;
   if (captured) {
-    return 10000 * captured + noisyhistory[color][piece - 2][captured - 2];
+    return 30000 + 10000 * captured + noisyhistory[color][piece - 2][captured - 2];
   } else {
     return quiethistory[color][piece - 2][to];
   }


### PR DESCRIPTION
Elo   | 1.83 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 46310 W: 12974 L: 12730 D: 20606
Penta | [48, 4410, 13996, 4652, 49]
http://sscg13.pythonanywhere.com/test/48/