### PR TITLE
no nmp in pv nodes

### DIFF
--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -258,7 +258,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
     return -1 * (28000 - ply);
   }
   if ((!incheck && Bitboards.gamephase[color] > 3) && (depth > 1 && nmp) &&
-      (staticeval >= beta)) {
+      (staticeval >= beta && !isPV)) {
     Bitboards.makenullmove();
     searchstack[ply].playedmove = 0;
     score = -alphabeta(std::max(0, depth - 2 - (depth + 1) / 3), ply + 1, -beta,


### PR DESCRIPTION
Elo   | 3.14 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15918 W: 4484 L: 4340 D: 7094
Penta | [20, 1451, 4871, 1599, 18]
http://sscg13.pythonanywhere.com/test/52/