### PR TITLE
Faster tt aging + net15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXE := Prolix
-EVALFILE := shatranj-net14.nnue
+EVALFILE := shatranj-net15.nnue
 
 SOURCES := Prolix.cpp external/Fathom/tbprobe.cpp
 

--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -213,7 +213,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
   int bestmove1 = -1;
   int ttdepth = TT[index].depth();
   int ttage = TT[index].age(Bitboards.gamelength);
-  bool update = (depth >= (ttdepth - ttage / 3));
+  bool update = (depth >= (ttdepth - ttage / 2));
   bool incheck = (Bitboards.checkers(color) != 0ULL);
   bool isPV = (beta - alpha > 1);
   int staticeval = useNNUE ? EUNN.evaluate(color) : Bitboards.evaluate(color);


### PR DESCRIPTION
Elo   | 1.90 +- 1.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 40718 W: 11490 L: 11267 D: 17961
Penta | [40, 3779, 12507, 3984, 49]
https://sscg13.pythonanywhere.com/test/55/

Elo   | 12.30 +- 5.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3052 W: 940 L: 832 D: 1280
Penta | [8, 259, 882, 371, 6]
https://sscg13.pythonanywhere.com/test/59/