### PR TITLE
Support for horizontally mirrored (+king bucketed) nets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXE := Prolix
-EVALFILE := shatranj-net15.nnue
+EVALFILE := shatranj-net16.nnue
 
 SOURCES := Prolix.cpp external/Fathom/tbprobe.cpp
 

--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -1079,6 +1079,12 @@ void Engine::uci() {
       }
     }
   }
+  if (ucicommand == "eval") {
+    int color = Bitboards.position & 1;
+    int eval = useNNUE ? EUNN.evaluate(color) : Bitboards.evaluate(color);
+    std::cout << "Raw eval: " << eval << "\n";
+    std::cout << "Normalized eval: " << normalize(eval) << "\n";
+  }
   if (ucicommand.substr(0, 3) == "see") {
     std::string mov = ucicommand.substr(4, ucicommand.length() - 4);
     int color = Bitboards.position & 1;

--- a/Prolix.cpp
+++ b/Prolix.cpp
@@ -156,12 +156,12 @@ int Engine::quiesce(int alpha, int beta, int color, int depth) {
     if (good) {
       Bitboards.makemove(mov, 1);
       if (useNNUE) {
-        EUNN.forwardaccumulators(mov);
+        EUNN.forwardaccumulators(mov, Bitboards.Bitboards);
       }
       score = -quiesce(-beta, -alpha, color ^ 1, depth + 1);
       Bitboards.unmakemove(mov);
       if (useNNUE) {
-        EUNN.backwardaccumulators(mov);
+        EUNN.backwardaccumulators(mov, Bitboards.Bitboards);
       }
       if (score >= beta) {
         return score;
@@ -336,7 +336,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
       Bitboards.makemove(mov, true);
       searchstack[ply].playedmove = mov;
       if (useNNUE) {
-        EUNN.forwardaccumulators(mov);
+        EUNN.forwardaccumulators(mov, Bitboards.Bitboards);
       }
       if (nullwindow) {
         score = -alphabeta(depth - 1 - r, ply + 1, -alpha - 1, -alpha,
@@ -354,7 +354,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
       }
       Bitboards.unmakemove(mov);
       if (useNNUE) {
-        EUNN.backwardaccumulators(mov);
+        EUNN.backwardaccumulators(mov, Bitboards.Bitboards);
       }
       if (score > bestscore) {
         if (score > alpha) {
@@ -557,7 +557,7 @@ int Engine::iterative(int color) {
     std::cout << "move " << algebraic(bestmove1) << std::endl;
     Bitboards.makemove(bestmove1, 0);
     if (useNNUE) {
-      EUNN.forwardaccumulators(bestmove1);
+      EUNN.forwardaccumulators(bestmove1, Bitboards.Bitboards);
     }
   }
   bestmove = bestmove1;
@@ -640,7 +640,7 @@ void Engine::datagenautoplay() {
       result = "0.5";
     }
     if (useNNUE && bestmove > 0) {
-      EUNN.forwardaccumulators(bestmove);
+      EUNN.forwardaccumulators(bestmove, Bitboards.Bitboards);
     }
   }
   for (int i = 0; i < maxmove; i++) {
@@ -698,7 +698,7 @@ void Engine::bookgenautoplay(int lowerbound, int upperbound) {
     } else {
       Bitboards.makemove(bestmove, 0);
       if (useNNUE) {
-        EUNN.forwardaccumulators(bestmove);
+        EUNN.forwardaccumulators(bestmove, Bitboards.Bitboards);
       }
     }
     if (Bitboards.twokings()) {
@@ -1204,7 +1204,7 @@ void Engine::xboard() {
     if (played >= 0) {
       Bitboards.makemove(Bitboards.moves[0][played], false);
       if (useNNUE) {
-        EUNN.forwardaccumulators(Bitboards.moves[0][played]);
+        EUNN.forwardaccumulators(Bitboards.moves[0][played], Bitboards.Bitboards);
       }
       if (gosent) {
         int color = Bitboards.position & 1;

--- a/nnue.cpp
+++ b/nnue.cpp
@@ -12,6 +12,7 @@ constexpr int outputbuckets = 8;
 constexpr int evalscale = 400;
 constexpr int evalQA = 255;
 constexpr int evalQB = 64;
+//clang-format off
 constexpr int kingbuckets[64] = {
   0, 0, 0, 0, 1, 1, 1, 1,
   0, 0, 0, 0, 1, 1, 1, 1,
@@ -22,16 +23,18 @@ constexpr int kingbuckets[64] = {
   2, 2, 2, 2, 3, 3, 3, 3,
   2, 2, 2, 2, 3, 3, 3, 3
 };
+//clang-format on
 constexpr int material[6] = {1, 1, 1, 1, 1, 0};
 constexpr int bucketdivisor = 32 / outputbuckets;
-constexpr int nnuefilesize =
-    (realbuckets * 1536 * nnuesize + 2 * nnuesize + 4 * nnuesize * outputbuckets + 2 * outputbuckets);
+constexpr int nnuefilesize = (realbuckets * 1536 * nnuesize + 2 * nnuesize +
+                              4 * nnuesize * outputbuckets + 2 * outputbuckets);
 INCBIN(char, NNUE, EUNNfile);
 int screlu(short int x) {
   return std::pow(std::max(std::min((int)x, 255), 0), 2);
 }
 int featureindex(int bucket, int piece, int color, int square) {
-  return 64 * piece + ((56 * color) ^ square ^ (7 * (mirrored && (bucket % 2 == 1))));
+  return 64 * piece +
+         ((56 * color) ^ square ^ (7 * (mirrored && (bucket % 2 == 1))));
 }
 class NNUE {
   short int nnuelayer1[realbuckets][768][nnuesize];
@@ -64,7 +67,7 @@ void NNUE::loaddefaultnet() {
       int convert[12] = {0, 3, 1, 4, 2, 5, 6, 9, 7, 10, 8, 11};
       for (int j = 0; j < nnuesize; j++) {
         short int weight = 256 * (short int)(NNUEData[offset + 1]) +
-                          (short int)(unsigned char)(NNUEData[offset]);
+                           (short int)(unsigned char)(NNUEData[offset]);
         nnuelayer1[k][64 * convert[piece] + square][j] = weight;
         offset += 2;
       }
@@ -110,7 +113,7 @@ void NNUE::readnnuefile(std::string file) {
       int convert[12] = {0, 3, 1, 4, 2, 5, 6, 9, 7, 10, 8, 11};
       for (int j = 0; j < nnuesize; j++) {
         short int weight = 256 * (short int)(weights[offset + 1]) +
-                          (short int)(unsigned char)(weights[offset]);
+                           (short int)(unsigned char)(weights[offset]);
         nnuelayer1[k][64 * convert[piece] + square][j] = weight;
         offset += 2;
       }
@@ -147,12 +150,16 @@ void NNUE::readnnuefile(std::string file) {
 }
 void NNUE::activatepiece(int bucket, int color, int piece, int square) {
   for (int i = 0; i < nnuesize; i++) {
-    accumulator[bucket][color][i] += nnuelayer1[bucket / mirrordivisor][featureindex(bucket, piece, color, square)][i];
+    accumulator[bucket][color][i] +=
+        nnuelayer1[bucket / mirrordivisor]
+                  [featureindex(bucket, piece, color, square)][i];
   }
 }
 void NNUE::deactivatepiece(int bucket, int color, int piece, int square) {
   for (int i = 0; i < nnuesize; i++) {
-    accumulator[bucket][color][i] -= nnuelayer1[bucket / mirrordivisor][featureindex(bucket, piece, color, square)][i];
+    accumulator[bucket][color][i] -=
+        nnuelayer1[bucket / mirrordivisor]
+                  [featureindex(bucket, piece, color, square)][i];
   }
 }
 void NNUE::refreshfromscratch(int bucket, int color, uint64_t *Bitboards) {
@@ -164,7 +171,7 @@ void NNUE::refreshfromscratch(int bucket, int color, uint64_t *Bitboards) {
     int piececount = __builtin_popcountll(pieces);
     for (int j = 0; j < piececount; j++) {
       int square = __builtin_popcountll((pieces & -pieces) - 1);
-      activatepiece(bucket, color, (i % 6) + 6 * (color ^ (i/6)), square);
+      activatepiece(bucket, color, (i % 6) + 6 * (color ^ (i / 6)), square);
       pieces ^= (1ULL << square);
     }
   }
@@ -180,8 +187,10 @@ void NNUE::initializennue(uint64_t *Bitboards) {
     int piececount = __builtin_popcountll(pieces);
     totalmaterial += piececount * material[i % 6];
   }
-  activebucket[0] = kingbuckets[__builtin_popcountll((Bitboards[0] & Bitboards[7]) - 1)];
-  activebucket[1] = kingbuckets[56 ^ __builtin_popcountll((Bitboards[1] & Bitboards[7]) - 1)];
+  activebucket[0] =
+      kingbuckets[__builtin_popcountll((Bitboards[0] & Bitboards[7]) - 1)];
+  activebucket[1] =
+      kingbuckets[56 ^ __builtin_popcountll((Bitboards[1] & Bitboards[7]) - 1)];
 }
 void NNUE::forwardaccumulators(int notation, uint64_t *Bitboards) {
   int from = notation & 63;
@@ -191,16 +200,17 @@ void NNUE::forwardaccumulators(int notation, uint64_t *Bitboards) {
   int captured = (notation >> 17) & 7;
   int promoted = (notation >> 21) & 3;
   int piece2 = (promoted > 0) ? piece : piece - 2;
-  activatepiece(activebucket[color ^ 1], color^1, 6 + piece2, to);
-  deactivatepiece(activebucket[color ^ 1], color^1, 4 + piece, from);
+  activatepiece(activebucket[color ^ 1], color ^ 1, 6 + piece2, to);
+  deactivatepiece(activebucket[color ^ 1], color ^ 1, 4 + piece, from);
   if (captured > 0) {
+    totalmaterial -= material[captured - 2];
     deactivatepiece(activebucket[color ^ 1], color ^ 1, captured - 2, to);
   }
-  if (piece == 7 && kingbuckets[to ^ (56 * color)] != kingbuckets[from ^ (56 * color)]) {
+  if (piece == 7 &&
+      kingbuckets[to ^ (56 * color)] != kingbuckets[from ^ (56 * color)]) {
     refreshfromscratch(kingbuckets[to ^ (56 * color)], color, Bitboards);
     activebucket[color] = kingbuckets[to ^ (56 * color)];
-  }
-  else {
+  } else {
     activatepiece(activebucket[color], color, piece2, to);
     deactivatepiece(activebucket[color], color, piece - 2, from);
     if (captured > 0) {
@@ -216,16 +226,17 @@ void NNUE::backwardaccumulators(int notation, uint64_t *Bitboards) {
   int captured = (notation >> 17) & 7;
   int promoted = (notation >> 21) & 3;
   int piece2 = promoted ? piece : piece - 2;
-  deactivatepiece(activebucket[color^1], color^1, 6 + piece2, to);
-  activatepiece(activebucket[color^1], color^1, 4 + piece, from);
+  deactivatepiece(activebucket[color ^ 1], color ^ 1, 6 + piece2, to);
+  activatepiece(activebucket[color ^ 1], color ^ 1, 4 + piece, from);
   if (captured > 0) {
-    activatepiece(activebucket[color^1], color ^ 1, captured - 2, to);
+    totalmaterial += material[captured - 2];
+    activatepiece(activebucket[color ^ 1], color ^ 1, captured - 2, to);
   }
-  if (piece == 7 && kingbuckets[to ^ (56 * color)] != kingbuckets[from ^ (56 * color)]) {
+  if (piece == 7 &&
+      kingbuckets[to ^ (56 * color)] != kingbuckets[from ^ (56 * color)]) {
     refreshfromscratch(kingbuckets[from ^ (56 * color)], color, Bitboards);
     activebucket[color] = kingbuckets[from ^ (56 * color)];
-  }
-  else {
+  } else {
     deactivatepiece(activebucket[color], color, piece2, to);
     activatepiece(activebucket[color], color, piece - 2, from);
     if (captured > 0) {
@@ -237,10 +248,12 @@ int NNUE::evaluate(int color) {
   int bucket = std::min(totalmaterial / bucketdivisor, outputbuckets - 1);
   int eval = finalbias[bucket] * evalQA;
   for (int i = 0; i < nnuesize; i++) {
-    eval += screlu(accumulator[activebucket[color]][color][i]) * ourlayer2[bucket][i];
+    eval += screlu(accumulator[activebucket[color]][color][i]) *
+            ourlayer2[bucket][i];
   }
   for (int i = 0; i < nnuesize; i++) {
-    eval += screlu(accumulator[activebucket[color^1]][color^1][i]) * theirlayer2[bucket][i];
+    eval += screlu(accumulator[activebucket[color ^ 1]][color ^ 1][i]) *
+            theirlayer2[bucket][i];
   }
   eval /= evalQA;
   eval *= evalscale;

--- a/nnue.cpp
+++ b/nnue.cpp
@@ -3,51 +3,71 @@
 #define INCBIN_PREFIX
 #include "external/incbin/incbin.h"
 
-const int nnuesize = 128;
-const int outputbuckets = 8;
-const int evalscale = 400;
-const int evalQA = 255;
-const int evalQB = 64;
-const int material[6] = {1, 1, 1, 1, 1, 0};
-const int bucketdivisor = 32 / outputbuckets;
-const int nnuefilesize =
-    (1538 * nnuesize + 4 * nnuesize * outputbuckets + 2 * outputbuckets);
+constexpr int inputbuckets = 4;
+constexpr bool mirrored = true;
+constexpr int mirrordivisor = mirrored ? 2 : 1;
+constexpr int realbuckets = inputbuckets / mirrordivisor;
+constexpr int nnuesize = 128;
+constexpr int outputbuckets = 8;
+constexpr int evalscale = 400;
+constexpr int evalQA = 255;
+constexpr int evalQB = 64;
+constexpr int kingbuckets[64] = {
+  0, 0, 0, 0, 1, 1, 1, 1,
+  0, 0, 0, 0, 1, 1, 1, 1,
+  0, 0, 0, 0, 1, 1, 1, 1,
+  2, 2, 2, 2, 3, 3, 3, 3,
+  2, 2, 2, 2, 3, 3, 3, 3,
+  2, 2, 2, 2, 3, 3, 3, 3,
+  2, 2, 2, 2, 3, 3, 3, 3,
+  2, 2, 2, 2, 3, 3, 3, 3
+};
+constexpr int material[6] = {1, 1, 1, 1, 1, 0};
+constexpr int bucketdivisor = 32 / outputbuckets;
+constexpr int nnuefilesize =
+    (realbuckets * 1536 * nnuesize + 2 * nnuesize + 4 * nnuesize * outputbuckets + 2 * outputbuckets);
 INCBIN(char, NNUE, EUNNfile);
 int screlu(short int x) {
   return std::pow(std::max(std::min((int)x, 255), 0), 2);
 }
+int featureindex(int bucket, int piece, int color, int square) {
+  return 64 * piece + ((56 * color) ^ square ^ (7 * (mirrored && (bucket % 2 == 1))));
+}
 class NNUE {
-  short int nnuelayer1[768][nnuesize];
+  short int nnuelayer1[realbuckets][768][nnuesize];
   short int layer1bias[nnuesize];
   int ourlayer2[outputbuckets][nnuesize];
   int theirlayer2[outputbuckets][nnuesize];
-  short int whitehidden[nnuesize];
-  short int blackhidden[nnuesize];
+  short int accumulator[inputbuckets][2][nnuesize];
   int finalbias[outputbuckets];
+  int activebucket[2];
   int totalmaterial;
 
 public:
   void loaddefaultnet();
   void readnnuefile(std::string file);
-  void activatepiece(int color, int piece, int square);
-  void deactivatepiece(int color, int piece, int square);
+  void activatepiece(int bucket, int color, int piece, int square);
+  void deactivatepiece(int bucket, int color, int piece, int square);
+  void refreshfromscratch(int bucket, int color, uint64_t *Bitboards);
   void initializennue(uint64_t *Bitboards);
-  void forwardaccumulators(int notation);
-  void backwardaccumulators(int notation);
+  void forwardaccumulators(int notation, uint64_t *Bitboards);
+  void backwardaccumulators(int notation, uint64_t *Bitboards);
   int evaluate(int color);
 };
 
 void NNUE::loaddefaultnet() {
   int offset = 0;
-  for (int i = 0; i < 768; i++) {
-    int piece = i / 64;
-    int square = i % 64;
-    int convert[12] = {0, 3, 1, 4, 2, 5, 6, 9, 7, 10, 8, 11};
-    for (int j = 0; j < nnuesize; j++) {
-      short int weight = 256 * (short int)(NNUEData[offset + 1]) +
-                         (short int)(unsigned char)(NNUEData[offset]);
-      nnuelayer1[64 * convert[piece] + square][j] = weight;
-      offset += 2;
+  for (int k = 0; k < realbuckets; k++) {
+    for (int i = 0; i < 768; i++) {
+      int piece = i / 64;
+      int square = i % 64;
+      int convert[12] = {0, 3, 1, 4, 2, 5, 6, 9, 7, 10, 8, 11};
+      for (int j = 0; j < nnuesize; j++) {
+        short int weight = 256 * (short int)(NNUEData[offset + 1]) +
+                          (short int)(unsigned char)(NNUEData[offset]);
+        nnuelayer1[k][64 * convert[piece] + square][j] = weight;
+        offset += 2;
+      }
     }
   }
   for (int i = 0; i < nnuesize; i++) {
@@ -83,15 +103,17 @@ void NNUE::readnnuefile(std::string file) {
   char *weights = new char[nnuefilesize];
   nnueweights.read(weights, nnuefilesize);
   int offset = 0;
-  for (int i = 0; i < 768; i++) {
-    int piece = i / 64;
-    int square = i % 64;
-    int convert[12] = {0, 3, 1, 4, 2, 5, 6, 9, 7, 10, 8, 11};
-    for (int j = 0; j < nnuesize; j++) {
-      short int weight = 256 * (short int)(weights[offset + 1]) +
-                         (short int)(unsigned char)(weights[offset]);
-      nnuelayer1[64 * convert[piece] + square][j] = weight;
-      offset += 2;
+  for (int k = 0; k < realbuckets; k++) {
+    for (int i = 0; i < 768; i++) {
+      int piece = i / 64;
+      int square = i % 64;
+      int convert[12] = {0, 3, 1, 4, 2, 5, 6, 9, 7, 10, 8, 11};
+      for (int j = 0; j < nnuesize; j++) {
+        short int weight = 256 * (short int)(weights[offset + 1]) +
+                          (short int)(unsigned char)(weights[offset]);
+        nnuelayer1[k][64 * convert[piece] + square][j] = weight;
+        offset += 2;
+      }
     }
   }
   for (int i = 0; i < nnuesize; i++) {
@@ -123,39 +145,45 @@ void NNUE::readnnuefile(std::string file) {
   delete[] weights;
   nnueweights.close();
 }
-void NNUE::activatepiece(int color, int piece, int square) {
+void NNUE::activatepiece(int bucket, int color, int piece, int square) {
   for (int i = 0; i < nnuesize; i++) {
-    whitehidden[i] += nnuelayer1[64 * (6 * color + piece) + square][i];
-    blackhidden[i] +=
-        nnuelayer1[64 * (6 * (color ^ 1) + piece) + 56 ^ square][i];
+    accumulator[bucket][color][i] += nnuelayer1[bucket / mirrordivisor][featureindex(bucket, piece, color, square)][i];
   }
-  totalmaterial += material[piece];
 }
-void NNUE::deactivatepiece(int color, int piece, int square) {
+void NNUE::deactivatepiece(int bucket, int color, int piece, int square) {
   for (int i = 0; i < nnuesize; i++) {
-    whitehidden[i] -= nnuelayer1[64 * (6 * color + piece) + square][i];
-    blackhidden[i] -=
-        nnuelayer1[64 * (6 * (color ^ 1) + piece) + 56 ^ square][i];
+    accumulator[bucket][color][i] -= nnuelayer1[bucket / mirrordivisor][featureindex(bucket, piece, color, square)][i];
   }
-  totalmaterial -= material[piece];
 }
-void NNUE::initializennue(uint64_t *Bitboards) {
-  totalmaterial = 0;
+void NNUE::refreshfromscratch(int bucket, int color, uint64_t *Bitboards) {
   for (int i = 0; i < nnuesize; i++) {
-    whitehidden[i] = layer1bias[i];
-    blackhidden[i] = layer1bias[i];
+    accumulator[bucket][color][i] = layer1bias[i];
   }
   for (int i = 0; i < 12; i++) {
     uint64_t pieces = (Bitboards[i / 6] & Bitboards[2 + (i % 6)]);
     int piececount = __builtin_popcountll(pieces);
     for (int j = 0; j < piececount; j++) {
       int square = __builtin_popcountll((pieces & -pieces) - 1);
-      activatepiece(i / 6, i % 6, square);
+      activatepiece(bucket, color, (i % 6) + 6 * (color ^ (i/6)), square);
       pieces ^= (1ULL << square);
     }
   }
 }
-void NNUE::forwardaccumulators(int notation) {
+void NNUE::initializennue(uint64_t *Bitboards) {
+  totalmaterial = 0;
+  for (int i = 0; i < inputbuckets; i++) {
+    refreshfromscratch(i, 0, Bitboards);
+    refreshfromscratch(i, 1, Bitboards);
+  }
+  for (int i = 0; i < 12; i++) {
+    uint64_t pieces = (Bitboards[i / 6] & Bitboards[2 + (i % 6)]);
+    int piececount = __builtin_popcountll(pieces);
+    totalmaterial += piececount * material[i % 6];
+  }
+  activebucket[0] = kingbuckets[__builtin_popcountll((Bitboards[0] & Bitboards[7]) - 1)];
+  activebucket[1] = kingbuckets[56 ^ __builtin_popcountll((Bitboards[1] & Bitboards[7]) - 1)];
+}
+void NNUE::forwardaccumulators(int notation, uint64_t *Bitboards) {
   int from = notation & 63;
   int to = (notation >> 6) & 63;
   int color = (notation >> 12) & 1;
@@ -163,13 +191,24 @@ void NNUE::forwardaccumulators(int notation) {
   int captured = (notation >> 17) & 7;
   int promoted = (notation >> 21) & 3;
   int piece2 = (promoted > 0) ? piece : piece - 2;
-  NNUE::activatepiece(color, piece2, to);
-  NNUE::deactivatepiece(color, piece - 2, from);
+  activatepiece(activebucket[color ^ 1], color^1, 6 + piece2, to);
+  deactivatepiece(activebucket[color ^ 1], color^1, 4 + piece, from);
   if (captured > 0) {
-    NNUE::deactivatepiece(color ^ 1, captured - 2, to);
+    deactivatepiece(activebucket[color ^ 1], color ^ 1, captured - 2, to);
+  }
+  if (piece == 7 && kingbuckets[to ^ (56 * color)] != kingbuckets[from ^ (56 * color)]) {
+    refreshfromscratch(kingbuckets[to ^ (56 * color)], color, Bitboards);
+    activebucket[color] = kingbuckets[to ^ (56 * color)];
+  }
+  else {
+    activatepiece(activebucket[color], color, piece2, to);
+    deactivatepiece(activebucket[color], color, piece - 2, from);
+    if (captured > 0) {
+      deactivatepiece(activebucket[color], color, 4 + captured, to);
+    }
   }
 }
-void NNUE::backwardaccumulators(int notation) {
+void NNUE::backwardaccumulators(int notation, uint64_t *Bitboards) {
   int from = notation & 63;
   int to = (notation >> 6) & 63;
   int color = (notation >> 12) & 1;
@@ -177,25 +216,31 @@ void NNUE::backwardaccumulators(int notation) {
   int captured = (notation >> 17) & 7;
   int promoted = (notation >> 21) & 3;
   int piece2 = promoted ? piece : piece - 2;
-  NNUE::deactivatepiece(color, piece2, to);
-  NNUE::activatepiece(color, piece - 2, from);
+  deactivatepiece(activebucket[color^1], color^1, 6 + piece2, to);
+  activatepiece(activebucket[color^1], color^1, 4 + piece, from);
   if (captured > 0) {
-    NNUE::activatepiece(color ^ 1, captured - 2, to);
+    activatepiece(activebucket[color^1], color ^ 1, captured - 2, to);
+  }
+  if (piece == 7 && kingbuckets[to ^ (56 * color)] != kingbuckets[from ^ (56 * color)]) {
+    refreshfromscratch(kingbuckets[from ^ (56 * color)], color, Bitboards);
+    activebucket[color] = kingbuckets[from ^ (56 * color)];
+  }
+  else {
+    deactivatepiece(activebucket[color], color, piece2, to);
+    activatepiece(activebucket[color], color, piece - 2, from);
+    if (captured > 0) {
+      activatepiece(activebucket[color], color, 4 + captured, to);
+    }
   }
 }
 int NNUE::evaluate(int color) {
   int bucket = std::min(totalmaterial / bucketdivisor, outputbuckets - 1);
   int eval = finalbias[bucket] * evalQA;
-  if (color == 0) {
-    for (int i = 0; i < nnuesize; i++) {
-      eval += screlu(whitehidden[i]) * ourlayer2[bucket][i];
-      eval += screlu(blackhidden[i]) * theirlayer2[bucket][i];
-    }
-  } else {
-    for (int i = 0; i < nnuesize; i++) {
-      eval += screlu(whitehidden[i]) * theirlayer2[bucket][i];
-      eval += screlu(blackhidden[i]) * ourlayer2[bucket][i];
-    }
+  for (int i = 0; i < nnuesize; i++) {
+    eval += screlu(accumulator[activebucket[color]][color][i]) * ourlayer2[bucket][i];
+  }
+  for (int i = 0; i < nnuesize; i++) {
+    eval += screlu(accumulator[activebucket[color^1]][color^1][i]) * theirlayer2[bucket][i];
   }
   eval /= evalQA;
   eval *= evalscale;


### PR DESCRIPTION
net16 (2 buckets, horizontally mirrored):
Elo   | 4.23 +- 3.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11262 W: 3257 L: 3120 D: 4885
Penta | [37, 1074, 3275, 1205, 40]
https://sscg13.pythonanywhere.com/test/61/