### PR TITLE
mate distance pruning

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -153,6 +153,13 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
     improving = (staticeval > searchstack[ply - 2].eval);
   }
   int quiets = 0;
+  if (!isPV) {
+    alpha = std::max(alpha, -28000 + ply);
+    beta  = std::min(beta,  28000 - ply - 1);
+    if (alpha >= beta) {
+      return alpha;
+    }
+  }
   if (tthit) {
     score = TT[index].score();
     ttmove = TT[index].hashmove();


### PR DESCRIPTION
Elo   | 0.19 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 24324 W: 6772 L: 6759 D: 10793
Penta | [18, 2032, 8047, 2049, 16]
https://sscg13.pythonanywhere.com/test/134/