### PR TITLE
tighten initial aspiration window

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -394,7 +394,7 @@ int Engine::iterative(int color) {
   }
   while (!stopsearch) {
     bestmove = -1;
-    int delta = 30;
+    int delta = 20;
     int alpha = returnedscore - delta;
     int beta = returnedscore + delta;
     bool fail = true;


### PR DESCRIPTION
Elo   | 1.86 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 40560 W: 11301 L: 11084 D: 18175
Penta | [24, 3616, 12788, 3823, 29]
https://sscg13.pythonanywhere.com/test/198/