### PR TITLE
extend if only one legal move

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -290,7 +290,7 @@ int Engine::alphabeta(int depth, int ply, int alpha, int beta, int color,
               -alphabeta(depth - 1, ply + 1, -beta, -alpha, color ^ 1, true);
         }
       } else {
-        score = -alphabeta(depth - 1, ply + 1, -beta, -alpha, color ^ 1, true);
+        score = -alphabeta(depth - 1 + e, ply + 1, -beta, -alpha, color ^ 1, true);
       }
       Bitboards.unmakemove(mov);
       if (useNNUE) {


### PR DESCRIPTION
Elo   | 2.43 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22910 W: 6442 L: 6282 D: 10186
Penta | [12, 2001, 7273, 2153, 16]
https://sscg13.pythonanywhere.com/test/213/