### PR TITLE
Distinguish TT entries ahead of current ply

### DIFF
--- a/src/Prolix.cpp
+++ b/src/Prolix.cpp
@@ -1,7 +1,7 @@
 #include "board.h"
 #include "engine.h"
-#include "external/Fathom/tbprobe.h"
 #include "eval/nnue.h"
+#include "external/Fathom/tbprobe.h"
 #include <thread>
 extern std::string uciinfostring;
 std::string proto = "uci";

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1,7 +1,7 @@
 #include "board.h"
 #include "consts.h"
-#include "external/Fathom/tbprobe.h"
 #include "eval/hce.h"
+#include "external/Fathom/tbprobe.h"
 U64 KingAttacks[64];
 U64 PawnAttacks[2][64];
 U64 AlfilAttacks[64];

--- a/src/datagen/datagen.cpp
+++ b/src/datagen/datagen.cpp
@@ -33,7 +33,7 @@ void Engine::datagenautoplayplain() {
     int color = Bitboards.position & 1;
     int score = iterative(color);
     if ((bestmove > 0) && (((bestmove >> 16) & 1) == 0) &&
-        (Bitboards.checkers(color) == 0ULL) && (abs(score) < 27000)) {
+        (Bitboards.checkers(color) == 0ULL) && (abs(score) < SCORE_WIN)) {
       fens[maxmove] = Bitboards.getFEN();
       scores[maxmove] = score * (1 - 2 * color);
       maxmove++;
@@ -168,7 +168,7 @@ void Engine::bookgenautoplay(int lowerbound, int upperbound) {
   bool finished = false;
   while (!finished) {
     int color = Bitboards.position & 1;
-    softnodelimit = color ? 4096 : 16384;
+    softnodelimit = color ? 2048 : 10240;
     int score = iterative(color);
     if ((bestmove > 0) && (((bestmove >> 16) & 1) == 0) &&
         (Bitboards.checkers(color) == 0ULL) && (abs(score) <= upperbound) &&
@@ -205,7 +205,7 @@ void Engine::datagen(int dataformat, int n, std::string outputfile) {
   } else {
     dataoutput.open(outputfile, std::ofstream::app);
   }
-  softnodelimit = 12288;
+  softnodelimit = 10240;
   hardnodelimit = 65536;
   softtimelimit = 0;
   hardtimelimit = 0;

--- a/src/engine.h
+++ b/src/engine.h
@@ -1,8 +1,8 @@
 #include "board.h"
 #include "consts.h"
+#include "eval/nnue.h"
 #include "external/Fathom/tbprobe.h"
 #include "history.h"
-#include "eval/nnue.h"
 #include "tt.h"
 #include <chrono>
 #include <time.h>

--- a/src/eval/nnue.h
+++ b/src/eval/nnue.h
@@ -1,5 +1,5 @@
-#include "arch.h"
 #include "../consts.h"
+#include "arch.h"
 #include <cstdint>
 #include <string>
 #pragma once

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -17,7 +17,7 @@ void TTentry::update(U64 hash, int gamelength, int depth, int ply, int score,
   data |= (((U64)depth) << 54);
 }
 int TTentry::age(int gamelength) {
-  return std::max((gamelength - ((int)(data >> 44) & 1023)), 0);
+  return (gamelength - ((int)(data >> 44) & 1023));
 }
 int TTentry::hashmove() { return (int)(data >> 16) & 0x03FFFFFF; }
 int TTentry::depth() { return (int)(data >> 54) & 63; }


### PR DESCRIPTION
Passes [-5, 0] nonreg with 6.18 LLR

Elo   | 0.85 +- 1.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.91 (-2.94, 2.94) [0.00, 5.00]
Games | N: 34288 W: 9392 L: 9308 D: 15588
Penta | [15, 3503, 10026, 3583, 17]
https://sscg13.pythonanywhere.com/test/564/