### PR TITLE
enable countermove bonus again

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -261,9 +261,9 @@ int Searcher::alphabeta(int depth, int ply, int alpha, int beta, int color,
     /*else if (moves[ply][i] == killers[ply][1]) {
       movescore[ply][i] += 10000;
     }*/
-    /*else if ((mov & 4095) == counter) {
+    else if ((mov & 4095) == counter) {
       movescore[i] += 10000;
-    }*/
+    }
     /*if (see_exceeds(moves[ply][i], color, 0)) {
         movescore[ply][i]+=15000;
     }*/


### PR DESCRIPTION
Elo   | 2.78 +- 2.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20758 W: 4803 L: 4637 D: 11318
Penta | [12, 2145, 5897, 2315, 10]
https://sscg13.pythonanywhere.com/test/1009/