### PR TITLE
Use TT in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -64,20 +64,6 @@ void Searcher::loadsearchlimits(Limits limits) {
 int Searcher::quiesce(int alpha, int beta, int color, int depth, bool isPV) {
   int index = Bitboards.zobristhash % *TTsize;
   TTentry &ttentry = (*TT)[index];
-  bool tthit = (ttentry.key == Bitboards.zobristhash);
-  if (!isPV && tthit) {
-    int score = std::min(std::max(ttentry.score(0), -SCORE_WIN), SCORE_WIN);
-    int nodetype = ttentry.nodetype();
-    if (nodetype == EXPECTED_PV_NODE) {
-      return score;
-    }
-    if ((nodetype & EXPECTED_CUT_NODE) && (score >= beta)) {
-      return score;
-    }
-    if ((nodetype & EXPECTED_ALL_NODE) && (score <= alpha)) {
-      return score;
-    }
-  }
   int score = useNNUE ? EUNN->evaluate(color) : Bitboards.evaluate(color);
   int bestscore = -SCORE_INF;
   int movcount;
@@ -101,7 +87,20 @@ int Searcher::quiesce(int alpha, int beta, int color, int depth, bool isPV) {
     }
     movcount = Bitboards.generatemoves(color, 1, moves);
   }
-
+  bool tthit = (ttentry.key == Bitboards.zobristhash);
+  if (!isPV && tthit) {
+    int score = std::min(std::max(ttentry.score(0), -SCORE_WIN), SCORE_WIN);
+    int nodetype = ttentry.nodetype();
+    if (nodetype == EXPECTED_PV_NODE) {
+      return score;
+    }
+    if ((nodetype & EXPECTED_CUT_NODE) && (score >= beta)) {
+      return score;
+    }
+    if ((nodetype & EXPECTED_ALL_NODE) && (score <= alpha)) {
+      return score;
+    }
+  }
   for (int i = 0; i < movcount - 1; i++) {
     for (int j = i + 1;
          Histories->movescore(moves[j]) > Histories->movescore(moves[j - 1]) &&

--- a/src/search.h
+++ b/src/search.h
@@ -37,7 +37,7 @@ class Searcher {
   std::random_device rd;
   std::mt19937 mt;
   void resetauxdata();
-  int quiesce(int alpha, int beta, int color, int depth);
+  int quiesce(int alpha, int beta, int color, int depth, bool isPV);
   int alphabeta(int depth, int ply, int alpha, int beta, int color, bool nmp,
                 int nodetype);
   int wdlmodel(int eval);


### PR DESCRIPTION
Move it after stand pat (effectively scuffed prefetch) to mitigate memory bottleneck issues
Elo   | 12.70 +- 5.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2984 W: 724 L: 615 D: 1645
Penta | [1, 276, 833, 377, 5]
https://sscg13.pythonanywhere.com/test/1024/