### PR TITLE
Prefetch TT entries

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -315,7 +315,7 @@ U64 Board::keyafter(int notation) {
   int captured = (notation >> 17) & 7;
   int promoted = (notation >> 21) & 3;
   int piece2 = (promoted > 0) ? piece + 2 : piece;
-  U64 change = (hashes[color][from] ^ hashes[color][to] ^ hashes[piece][from] ^ hashes[piece2][to]);
+  U64 change = (colorhash ^ hashes[color][from] ^ hashes[color][to] ^ hashes[piece][from] ^ hashes[piece2][to]);
   if (captured) {
     change ^= (hashes[color ^ 1][to] ^ hashes[captured][to]);
   }

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -307,6 +307,20 @@ void Board::unmakenullmove() {
   position = history[gamelength];
   zobristhash = zobrist[gamelength];
 }
+U64 Board::keyafter(int notation) {
+  int from = notation & 63;
+  int to = (notation >> 6) & 63;
+  int color = (notation >> 12) & 1;
+  int piece = (notation >> 13) & 7;
+  int captured = (notation >> 17) & 7;
+  int promoted = (notation >> 21) & 3;
+  int piece2 = (promoted > 0) ? piece + 2 : piece;
+  U64 change = (hashes[color][from] ^ hashes[color][to] ^ hashes[piece][from] ^ hashes[piece2][to]);
+  if (captured) {
+    change ^= (hashes[color ^ 1][to] ^ hashes[captured][to]);
+  }
+  return zobristhash ^ change;
+}
 void Board::makemove(int notation, bool reversible) {
   // 6 bits from square, 6 bits to square, 1 bit color, 3 bits piece moved, 1
   // bit capture, 3 bits piece captured, 1 bit promotion, 2 bits promoted piece,

--- a/src/board.h
+++ b/src/board.h
@@ -36,6 +36,7 @@ public:
   U64 checkers(int color);
   void makenullmove();
   void unmakenullmove();
+  U64 keyafter(int notation);
   void makemove(int notation, bool reversible);
   void unmakemove(int notation);
   int generatemoves(int color, bool capturesonly, int *movelist);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -112,7 +112,7 @@ int Searcher::quiesce(int alpha, int beta, int color, int depth, bool isPV) {
   for (int i = 0; i < movcount; i++) {
     int mov = moves[i];
     int nextindex = (Bitboards.keyafter(mov) % *TTsize);
-    __builtin_prefetch((&(*TT)[index]), 0, 0);
+    __builtin_prefetch((&(*TT)[nextindex]), 0, 0);
     bool good = (incheck || Bitboards.see_exceeds(mov, color, 0));
     if (good) {
       Bitboards.makemove(mov, 1);
@@ -297,7 +297,7 @@ int Searcher::alphabeta(int depth, int ply, int alpha, int beta, int color,
     bool prune = false;
     int mov = moves[i];
     int nextindex = (Bitboards.keyafter(mov) % *TTsize);
-    __builtin_prefetch(&((*TT)[index]), 0, 0);
+    __builtin_prefetch(&((*TT)[nextindex]), 0, 0);
     if (!iscapture(mov)) {
       quiets++;
       if (i > depth * depth + depth + 4) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -111,6 +111,8 @@ int Searcher::quiesce(int alpha, int beta, int color, int depth, bool isPV) {
   }
   for (int i = 0; i < movcount; i++) {
     int mov = moves[i];
+    int nextindex = (Bitboards.keyafter(mov) % *TTsize);
+    __builtin_prefetch((&(*TT)[index]), 0, 0);
     bool good = (incheck || Bitboards.see_exceeds(mov, color, 0));
     if (good) {
       Bitboards.makemove(mov, 1);
@@ -294,6 +296,8 @@ int Searcher::alphabeta(int depth, int ply, int alpha, int beta, int color,
     int r = 0;
     bool prune = false;
     int mov = moves[i];
+    int nextindex = (Bitboards.keyafter(mov) % *TTsize);
+    __builtin_prefetch(&((*TT)[index]), 0, 0);
     if (!iscapture(mov)) {
       quiets++;
       if (i > depth * depth + depth + 4) {


### PR DESCRIPTION
Elo   | 9.23 +- 4.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3990 W: 955 L: 849 D: 2186
Penta | [1, 354, 1180, 458, 2]
https://sscg13.pythonanywhere.com/test/1038/