### PR TITLE
Add SMP support

### DIFF
--- a/src/Prolix.cpp
+++ b/src/Prolix.cpp
@@ -2,7 +2,6 @@
 #include "engine.h"
 #include "eval/nnue.h"
 #include "external/Fathom/tbprobe.h"
-#include <thread>
 extern std::string uciinfostring;
 std::string proto = "uci";
 std::string inputfile;
@@ -22,7 +21,7 @@ void Engine::bench() {
       "1r2q3/R4pn1/1p1pkn2/3p1p2/1PpP2p1/N1P1K1P1/3Q3P/2B1R3 b - - 5 31",
       "8/1Q6/3Q4/3p1p2/2pkq2R/5q2/5K2/8 w - - 2 116",
       "8/4k3/4R3/2PK4/1P3Nn1/P2PPn2/5r2/8 b - - 2 58"};
-  master.searchoptions.suppressoutput = true;
+  searchoptions.suppressoutput = true;
   auto commence = std::chrono::steady_clock::now();
   int nodes = 0;
   searchlimits.softnodelimit = 0;
@@ -33,8 +32,7 @@ void Engine::bench() {
     startup();
     searchlimits.maxdepth = 17;
     Bitboards.parseFEN(benchfens[i]);
-    master.loadposition(Bitboards);
-    master.loadsearchlimits(searchlimits);
+    master.syncwith(*this);
     int color = Bitboards.position & 1;
     master.iterative(color);
     nodes += master.Bitboards.nodecount;

--- a/src/engine.h
+++ b/src/engine.h
@@ -6,6 +6,7 @@
 #include "search.h"
 #include "tt.h"
 #include <chrono>
+#include <thread>
 #include <time.h>
 #pragma once
 extern std::string proto;
@@ -27,12 +28,15 @@ class Engine {
   std::random_device rd;
   std::mt19937 mt;
   std::ofstream dataoutput;
+  int threads = 1;
   Searcher master;
   void initializett();
 
 public:
+  friend class Searcher;
   void startup();
   void bench();
+  void spawnworker();
   void datagen(int dataformat, int threads, int n, std::string outputfile);
   void bookgen(int lowerbound, int upperbound, int threads, int n,
                std::string outputfile);

--- a/src/engine.h
+++ b/src/engine.h
@@ -17,16 +17,13 @@ class Engine {
   int TTsize = 2097152;
   std::vector<TTentry> TT;
   Board Bitboards;
-  bool useNNUE = true;
-  bool normalizeeval = true;
-  bool showWDL = true;
   bool gosent = false;
   std::atomic<bool> stopsearch = ATOMIC_VAR_INIT(false);
-  bool useTB = false;
   abinfo searchstack[maxmaxdepth + 32];
   int pvtable[maxmaxdepth + 1][maxmaxdepth + 1];
   int bestmove = 0;
   Limits searchlimits;
+  Options searchoptions;
   std::random_device rd;
   std::mt19937 mt;
   std::ofstream dataoutput;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -13,7 +13,6 @@ void initializelmr() {
 }
 void Engine::startup() {
   searchlimits.maxdepth = maxmaxdepth;
-  searchlimits.movetime = 0;
   initializett();
   Bitboards.initialize();
   master.setTT(TT, TTsize);
@@ -57,6 +56,7 @@ void Searcher::loadposition(Board board) {
   EUNN->initializennue(Bitboards.Bitboards);
 }
 void Searcher::loadsearchlimits(Limits limits) { searchlimits = limits; }
+void Searcher::loadsearchoptions(Options options) { searchoptions = options; }
 int Searcher::quiesce(int alpha, int beta, int color, int depth, bool isPV) {
   int index = Bitboards.zobristhash % *TTsize;
   TTentry &ttentry = (*TT)[index];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -584,6 +584,10 @@ int Searcher::iterative(int color) {
     }
   }
   bestmove = bestmove1;
+  if (!ismaster) {
+    delete Histories;
+    delete EUNN;
+  }
   return returnedscore;
 }
 void Engine::spawnworker() {

--- a/src/search.h
+++ b/src/search.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <time.h>
 #pragma once
+class Engine;
 struct abinfo {
   int playedmove;
   int eval;
@@ -29,6 +30,9 @@ struct Options {
 class Searcher {
   NNUE *EUNN = new NNUE;
   History *Histories = new History;
+  std::vector<TTentry> *TT;
+  int *TTsize;
+  int *signal;
   int killers[maxmaxdepth][2];
   int countermoves[6][64];
   std::atomic<bool> *stopsearch;
@@ -46,14 +50,13 @@ class Searcher {
   int normalize(int eval);
 
 public:
-  std::vector<TTentry> *TT;
-  int *TTsize;
   Board Bitboards;
   Limits searchlimits;
   Options searchoptions;
   std::ofstream dataoutput;
   bool ismaster = true;
   void seedrng();
+  void syncwith(Engine &engine);
   void setstopsearch(std::atomic<bool> &stopsearchref);
   void setTT(std::vector<TTentry> &TTref, int &size);
   void loadposition(Board board);

--- a/src/search.h
+++ b/src/search.h
@@ -18,7 +18,6 @@ struct Limits {
   int softtimelimit;
   int hardtimelimit;
   int maxdepth;
-  int movetime;
 };
 struct Options {
   bool useNNUE = true;
@@ -59,6 +58,7 @@ public:
   void setTT(std::vector<TTentry> &TTref, int &size);
   void loadposition(Board board);
   void loadsearchlimits(Limits limits);
+  void loadsearchoptions(Options options);
   int iterative(int color);
   void datagenautoplayplain();
   void datagenautoplayviriformat();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -45,6 +45,7 @@ void Engine::uci() {
       for (int i = 0; i < 6; i++) {
         tokens >> token;
         fen += token;
+        fen += " ";
       }
     }
     Bitboards.parseFEN(fen);


### PR DESCRIPTION
Prints single threaded node counts
Seems to be around 60 elo per doubling
No functional change to single thread search.
Elo   | 61.99 +- 12.15 (95%)
Conf  | 8.0+0.08s Threads=2 Hash=32MB
Games | N: 708 W: 220 L: 95 D: 393
Penta | [0, 32, 166, 155, 1]
https://sscg13.pythonanywhere.com/test/1114/