### PR TITLE
reduce more in expected cut nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -308,6 +308,7 @@ int Searcher::alphabeta(int depth, int ply, int alpha, int beta, int color,
     }
     r -= 1024 * isPV;
     r -= 1024 * improving;
+    r += 512 * (nodetype == EXPECTED_CUT_NODE);
     r = std::max(0, r);
     if (nullwindow && !incheck && !prune && depth < 6) {
       int threshold = iscapture(mov) ? -30 * depth * depth : -100 * depth;


### PR DESCRIPTION
Elo   | 2.32 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29350 W: 6786 L: 6590 D: 15974
Penta | [16, 3051, 8346, 3245, 17]
https://sscg13.pythonanywhere.com/test/1102/