### PR TITLE
Implement finny tables again

### DIFF
--- a/src/eval/nnue.h
+++ b/src/eval/nnue.h
@@ -21,14 +21,19 @@ class NNUE {
   NNUEWeights* weights;
   int totalmaterial;
   int ply;
+  short int cacheaccumulators[inputbuckets][2][nnuesize];
+  uint64_t cachebitboards[inputbuckets][2][8];
   short int accumulation[2 * maxmaxdepth + 64][nnuesize];
 
 public:
+  int getbucket(int kingsquare, int color);
   int featureindex(int bucket, int color, int piece, int square);
+  int differencecount(int bucket, int color, const uint64_t *Bitboards);
   const short int *layer1weights(int kingsquare, int color, int piece,
                                  int square);
-  void activatepiece(int kingsquare, int color, int piece, int square);
-  void deactivatepiece(int kingsquare, int color, int piece, int square);
+  void activatepiece(short int* accptr, int kingsquare, int color, int piece, int square);
+  void deactivatepiece(short int* accptr, int kingsquare, int color, int piece, int square);
+  void refreshfromcache(int kingsquare, int color, const uint64_t *Bitboards);
   void refreshfromscratch(int kingsquare, int color, const uint64_t *Bitboards);
   void initializennue(const uint64_t *Bitboards);
   void forwardaccumulators(const int notation, const uint64_t *Bitboards);


### PR DESCRIPTION
Elo   | 1.78 +- 2.00 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 0.51 (-2.94, 2.94) [0.00, 5.00]
Games | N: 48468 W: 16734 L: 16485 D: 15249
Penta | [1794, 2802, 14863, 2911, 1864]
https://sscg13.pythonanywhere.com/test/1123/

Is a bench speedup of around +10% on a larger net using 8 buckets instead of 2 (2.5M current vs 2.75M finny)