### PR TITLE
extend datagen random ply + filter too unbalanced exits

### DIFF
--- a/src/datagen/datagen.cpp
+++ b/src/datagen/datagen.cpp
@@ -8,7 +8,7 @@ void Searcher::datagenautoplayplain() {
   std::string game = "";
   std::string result = "";
   int moves[maxmoves];
-  for (int i = 0; i < 8; i++) {
+  for (int i = 0; i < 16; i++) {
     int num_moves = Bitboards.generatemoves(i & 1, 0, moves);
     if (num_moves == 0) {
       return;
@@ -22,6 +22,10 @@ void Searcher::datagenautoplayplain() {
     EUNN.initializennue(Bitboards.Bitboards);
   }
   if (Bitboards.generatemoves(0, 0, moves) == 0) {
+    return;
+  }
+  int score = quiesce(-SCORE_INF, SCORE_INF, 0, true);
+  if (std::abs(score) > 400) {
     return;
   }
   std::string fens[1024];


### PR DESCRIPTION
Elo   | 11.28 +- 5.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3760 W: 924 L: 802 D: 2034
Penta | [20, 372, 966, 510, 12]
http://sscg13.pythonanywhere.com/test/1213/
Equal data test on a net 1/8 size, ~38M pos

Additional tests:
http://sscg13.pythonanywhere.com/test/1203/
http://sscg13.pythonanywhere.com/test/1204/
http://sscg13.pythonanywhere.com/test/1205/
http://sscg13.pythonanywhere.com/test/1206/
http://sscg13.pythonanywhere.com/test/1207/
http://sscg13.pythonanywhere.com/test/1208/