### PR TITLE
win adjudication, 1000 internal units, 5 ply

### DIFF
--- a/src/datagen/datagen.cpp
+++ b/src/datagen/datagen.cpp
@@ -32,6 +32,7 @@ void Searcher::datagenautoplayplain() {
   int scores[1024];
   int maxmove = 0;
   bool finished = false;
+  int wincount = 0;
   while (!finished) {
     int color = Bitboards.position & 1;
     int score = iterative();
@@ -47,9 +48,14 @@ void Searcher::datagenautoplayplain() {
     } else {
       Bitboards.makemove(bestmove, 0);
     }
-    if (abs(score) >= SCORE_WIN) {
+    if (abs(score) >= 1000) {
+      wincount++;
+    } else {
+      wincount = 0;
+    }
+    if (wincount >= 5) {
       finished = true;
-      if (score * (1 - 2 * color) >= SCORE_WIN) {
+      if (score * (1 - 2 * color) >= 1000) {
         result = "1.0";
       } else {
         result = "0.0";


### PR DESCRIPTION
Elo   | 8.82 +- 5.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4964 W: 1238 L: 1112 D: 2614
Penta | [20, 522, 1278, 636, 26]
https://sscg13.pythonanywhere.com/test/1229/
