### PR TITLE
draw adjudication in datagen

### DIFF
--- a/src/datagen/datagen.cpp
+++ b/src/datagen/datagen.cpp
@@ -33,6 +33,7 @@ void Searcher::datagenautoplayplain() {
   int maxmove = 0;
   bool finished = false;
   int wincount = 0;
+  int drawcount = 0;
   while (!finished) {
     int color = Bitboards.position & 1;
     int score = iterative();
@@ -53,6 +54,11 @@ void Searcher::datagenautoplayplain() {
     } else {
       wincount = 0;
     }
+    if (abs(score) <= 15 && maxmove >= 40) {
+      drawcount++;
+    } else {
+      drawcount = 0;
+    }
     if (wincount >= 5) {
       finished = true;
       if (score * (1 - 2 * color) >= 1000) {
@@ -60,6 +66,10 @@ void Searcher::datagenautoplayplain() {
       } else {
         result = "0.0";
       }
+    }
+    else if (drawcount >= 8) {
+      finished = true;
+      result = "0.5";
     }
     else if (Bitboards.twokings()) {
       finished = true;


### PR DESCRIPTION
Elo   | 3.14 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19998 W: 4792 L: 4611 D: 10595
Penta | [68, 2261, 5180, 2402, 88]
https://sscg13.pythonanywhere.com/test/1239/

actually even with less positions (33M vs 38M)