### PR TITLE
Do not sample positions with high halfmove count

### DIFF
--- a/src/datagen/datagen.cpp
+++ b/src/datagen/datagen.cpp
@@ -33,6 +33,7 @@ void Searcher::datagenautoplayplain() {
   int maxmove = 0;
   bool finished = false;
   int wincount = 0;
+  int drawcount = 0;
   while (!finished) {
     int color = Bitboards.position & 1;
     int score = iterative();
@@ -53,6 +54,11 @@ void Searcher::datagenautoplayplain() {
     } else {
       wincount = 0;
     }
+    if (abs(score) <= 15 && maxmove >= 40) {
+      drawcount++;
+    } else {
+      drawcount = 0;
+    }
     if (wincount >= 5) {
       finished = true;
       if (score * (1 - 2 * color) >= 1000) {
@@ -60,6 +66,10 @@ void Searcher::datagenautoplayplain() {
       } else {
         result = "0.0";
       }
+    }
+    else if (drawcount >= 8) {
+      finished = true;
+      result = "0.5";
     }
     else if (Bitboards.twokings()) {
       finished = true;

--- a/src/datagen/datagen.cpp
+++ b/src/datagen/datagen.cpp
@@ -37,7 +37,7 @@ void Searcher::datagenautoplayplain() {
   while (!finished) {
     int color = Bitboards.position & 1;
     int score = iterative();
-    if ((bestmove > 0) && (((bestmove >> 16) & 1) == 0) &&
+    if (((Bitboards.position >> 1) < 40) && (((bestmove >> 16) & 1) == 0) &&
         (Bitboards.checkers(color) == 0ULL) && (abs(score) < SCORE_WIN)) {
       fens[maxmove] = Bitboards.getFEN();
       scores[maxmove] = score * (1 - 2 * color);


### PR DESCRIPTION
Prevents huge repetition of draws going all the way to 70 move rule
Elo   | 26.19 +- 8.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1542 W: 429 L: 313 D: 800
Penta | [5, 124, 405, 224, 13]
https://sscg13.pythonanywhere.com/test/1256/