### PR TITLE
fail soft in nmp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -242,7 +242,7 @@ int Searcher::alphabeta(int depth, int ply, int alpha, int beta, bool nmp,
                        1 - beta, false, childnodetype);
     Bitboards.unmakenullmove();
     if (score >= beta) {
-      return beta;
+      return std::abs(score) < SCORE_MAX_EVAL ? score : beta;
     }
   }
   /*if ((depth < 3) && (staticeval + 200*depth < alpha) && !isPV) {


### PR DESCRIPTION
Elo   | 6.12 +- 3.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6758 W: 1586 L: 1467 D: 3705
Penta | [1, 664, 1932, 779, 3]
https://sscg13.pythonanywhere.com/test/1266/