### PR TITLE
store qsearch results into tt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -60,6 +60,8 @@ int Searcher::quiesce(int alpha, int beta, int ply, bool isPV) {
   int score =
       searchoptions.useNNUE ? EUNN.evaluate(color) : Bitboards.evaluate(color);
   int bestscore = -SCORE_INF;
+  int savednodetype = EXPECTED_ALL_NODE;
+  int bestmove1 = 0;
   int movcount;
   if (ply > maxmaxdepth+30) {
     return score;
@@ -119,15 +121,25 @@ int Searcher::quiesce(int alpha, int beta, int ply, bool isPV) {
         EUNN.backwardaccumulators(mov, Bitboards.Bitboards);
       }
       if (score >= beta) {
+        if (!tthit) {
+          ttentry.update(Bitboards.zobristhash, Bitboards.gamelength, 0,
+                             ply, false, score, EXPECTED_CUT_NODE, mov);
+          }
         return score;
       }
       if (score > alpha) {
+        savednodetype = EXPECTED_PV_NODE;
+        bestmove1 = mov;
         alpha = score;
       }
       if (score > bestscore) {
         bestscore = score;
       }
     }
+  }
+  if (!tthit) {
+    ttentry.update(Bitboards.zobristhash, Bitboards.gamelength, 0,
+                             ply, (savednodetype == EXPECTED_PV_NODE), score, EXPECTED_CUT_NODE, bestmove1);
   }
   return bestscore;
 }


### PR DESCRIPTION
Elo   | 7.51 +- 4.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5318 W: 1291 L: 1176 D: 2851
Penta | [1, 524, 1496, 635, 3]
https://sscg13.pythonanywhere.com/test/1292/